### PR TITLE
Add a binary

### DIFF
--- a/deterministic-tar
+++ b/deterministic-tar
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+var deterministic = require('./index.js')
+
+process.stdin
+  .pipe(deterministic())
+  .pipe(process.stdout)

--- a/index.js
+++ b/index.js
@@ -30,8 +30,3 @@ var deterministic = module.exports = function (map) {
 
   return duplexer(extract, pack)
 }
-
-if(!module.parent)
-  process.stdin
-    .pipe(deterministic())
-    .pipe(process.stdout)

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "deterministic-tar",
   "description": "generate a tarball that hashes consistently",
   "version": "0.1.2",
+  "bin": "./deterministic-tar",
   "homepage": "https://github.com/dominictarr/deterministic-tar",
   "repository": {
     "type": "git",


### PR DESCRIPTION
So that after `npm install -g deterministic-tar`, you can then run `deterministic-tar < foo.tar > bar.tar`